### PR TITLE
[#32] set file suffix to kind when specifying template name

### DIFF
--- a/k8t/cli.py
+++ b/k8t/cli.py
@@ -192,9 +192,16 @@ def new_template(cname, ename, name, prefix, kind, directory):
 
     makedirs(template_dir, warn_exists=False)
 
+    suffix = None if not name else "-{}".format(kind)
+
     scaffolding.new_template(
         kind, os.path.join(
-            template_dir, "{0}{1}.yaml.j2".format(prefix or '', name or kind))
+            template_dir,
+            "{0}{1}{2}.yaml.j2".format(
+                prefix or '',
+                name or kind,
+                suffix or ''
+            ))
     )
 
 


### PR DESCRIPTION
avoids the issue of filenames colliding when scaffolding templates