### PR TITLE
[CLOUD-931] removing hard-coded slash symbols for get_secret function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 __pycache__
 build
 dist
+
+.python-version

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Setup secrets on SSM
 ```yaml
 secrets:
   provider: ssm
+  region: "eu-central-1"
   prefix: "/foobar"
 ```
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Secrets can be interpolated with the helper function `get_secret`. It requires a
 are configurable by environment/cluster.
 
 ```yaml
-foobar: "{{ get_secret('/my-key/') }}"
+foobar: "{{ get_secret('/my-key') }}"
 ```
 
 #### Providers
@@ -191,6 +191,10 @@ secrets:
   provider: ssm
   prefix: "/foobar"
 ```
+
+> Keep in mind that SSM parameter names can be formed as a path and  they can only consist of sub-paths divided by slash symbol; each sub-path can be formed as a mix of letters, numbers and the following 3 symbols: `.-_`
+>
+> Be careful to follow this format when setting up the provider `prefix` and `get_secret(key)`.
 
 ##### Random
 

--- a/examples/single-cluster/environments/production/config.yaml
+++ b/examples/single-cluster/environments/production/config.yaml
@@ -1,3 +1,4 @@
 secrets:
   provider: ssm
+  region: 'eu-central-1'
   prefix: '/production'

--- a/k8t/filters.py
+++ b/k8t/filters.py
@@ -82,10 +82,12 @@ def hashf(value, method="sha256"):
 
 def get_secret(key: str, length: int = None) -> str:
     try:
+        default_region = "eu-central-1"
         provider = getattr(secret_providers, config.CONFIG["secrets"]["provider"].lower())
 
         return provider(
             "{0}{1}".format(config.CONFIG['secrets']['prefix'], key) if "prefix" in config.CONFIG["secrets"] else key,
+            "{}".format(config.CONFIG['secrets']['region']) if "region" in config.CONFIG["secrets"] else default_region,
             length
         )
     except AttributeError:

--- a/k8t/filters.py
+++ b/k8t/filters.py
@@ -85,7 +85,7 @@ def get_secret(key: str, length: int = None) -> str:
         provider = getattr(secret_providers, config.CONFIG["secrets"]["provider"].lower())
 
         return provider(
-            "{0}/{1}".format(config.CONFIG['secrets']['prefix'], key) if "prefix" in config.CONFIG["secrets"] else key,
+            "{0}{1}".format(config.CONFIG['secrets']['prefix'], key) if "prefix" in config.CONFIG["secrets"] else key,
             length
         )
     except AttributeError:

--- a/k8t/secret_providers.py
+++ b/k8t/secret_providers.py
@@ -22,10 +22,10 @@ LOGGER = logging.getLogger(__name__)
 RANDOM_STORE = {}
 
 
-def ssm(key: str, length: int = None) -> str:
+def ssm(key: str, region: str, length: int = None) -> str:
     LOGGER.debug("Requesting secret from %s", key)
 
-    client = boto3.client("ssm")
+    client = boto3.client("ssm", region_name=region)
 
     try:
         result = client.get_parameter(Name=key, WithDecryption=True)["Parameter"]["Value"]

--- a/k8t/secret_providers.py
+++ b/k8t/secret_providers.py
@@ -28,7 +28,7 @@ def ssm(key: str, length: int = None) -> str:
     client = boto3.client("ssm")
 
     try:
-        result = client.get_parameter(Name="/{}".format(key), WithDecryption=True)["Parameter"]["Value"]
+        result = client.get_parameter(Name=key, WithDecryption=True)["Parameter"]["Value"]
 
         if length is not None:
             if len(result) != length:
@@ -46,5 +46,9 @@ def random(key: str, length: int = None) -> str:
         RANDOM_STORE[key] = "".join(
             SystemRandom().choice(string.ascii_lowercase + string.digits) for _ in range(length or SystemRandom().randint(12, 32))
         )
+
+        if length is not None:
+            if len(RANDOM_STORE[key]) != length:
+                raise AssertionError("Secret '{}' did not have expected length of {}".format(key, length))
 
     return RANDOM_STORE[key]

--- a/tests/secret_providers.py
+++ b/tests/secret_providers.py
@@ -26,7 +26,8 @@ def test_random():
 
 @mock_ssm
 def test_ssm():
-    client = boto3.client("ssm", region_name="eu-central-1")
+    region = "eu-central-1"
+    client = boto3.client("ssm", region_name=region)
 
     client.put_parameter(
         Name="foo",
@@ -51,16 +52,18 @@ def test_ssm():
         KeyId="alias/aws/ssm",
     )
 
-    response = ssm("foo")
+    response = ssm("foo", region)
     assert response == 'global_secret_value'
-    response = ssm("/dev/test1")
+    response = ssm("/dev/test1", region)
     assert response == 'string_value'
-    response = ssm("/app/dev/password")
+    response = ssm("/app/dev/password", region)
     assert response == 'my_secret_value'
 
 @mock_ssm
 def test_ssm_nonexistent_parameter():
+    region = "eu-central-1"
+
     with pytest.raises(RuntimeError, match=r"Could not find secret: /Application/non_existent"):
-        ssm("/Application/non_existent")
+        ssm("/Application/non_existent", region)
 
 # vim: fenc=utf-8:ts=4:sw=4:expandtab

--- a/tests/secret_providers.py
+++ b/tests/secret_providers.py
@@ -7,7 +7,11 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+import boto3
+import pytest
+from moto import mock_ssm
 from k8t.secret_providers import random
+from k8t.secret_providers import ssm
 
 
 def test_random():
@@ -18,5 +22,45 @@ def test_random():
     result = random('/foobam', length)
 
     assert result == random('/foobam', length)
+
+
+@mock_ssm
+def test_ssm():
+    client = boto3.client("ssm", region_name="eu-central-1")
+
+    client.put_parameter(
+        Name="foo",
+        Description="Global parameter",
+        Value="global_secret_value",
+        Type="SecureString",
+        KeyId="alias/aws/ssm",
+    )
+
+    client.put_parameter(
+        Name="/dev/test1",
+        Description="Environment specific simple parameter",
+        Value="string_value",
+        Type="String",
+    )
+
+    client.put_parameter(
+        Name="/app/dev/password",
+        Description="Environment specific secret.",
+        Value="my_secret_value",
+        Type="SecureString",
+        KeyId="alias/aws/ssm",
+    )
+
+    response = ssm("foo")
+    assert response == 'global_secret_value'
+    response = ssm("/dev/test1")
+    assert response == 'string_value'
+    response = ssm("/app/dev/password")
+    assert response == 'my_secret_value'
+
+@mock_ssm
+def test_ssm_nonexistent_parameter():
+    with pytest.raises(RuntimeError, match=r"Could not find secret: /Application/non_existent"):
+        ssm("/Application/non_existent")
 
 # vim: fenc=utf-8:ts=4:sw=4:expandtab

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist = py3
 passenv = *
 deps = pytest
        mock
+       boto3
+       moto
 commands = py.test {posargs}
 #           py.test --doctest-module README.rst
 


### PR DESCRIPTION
[CLOUD-931] removing hard-coded slash symbols for get_secret function to avoid malformed parameter names.
[CLOUD-931] retrieve ssm parameter from specific region

fixes #46 

[CLOUD-931]: https://clarkteam.atlassian.net/browse/CLOUD-931