### PR TITLE
Fix random secret_provider

### DIFF
--- a/k8t/config.py
+++ b/k8t/config.py
@@ -24,3 +24,7 @@ def load_all(root: str, cluster: str, environment: str, method: str) -> Dict[str
     LOGGER.debug("using config files: %s", configs)
 
     return deep_merge(*[load_yaml(f) for f in configs], method=method)
+
+
+def get_secrets(key: str, default: Any = None) -> Any:
+    return CONFIG.get("secrets", {}).get(key, default)

--- a/k8t/config.py
+++ b/k8t/config.py
@@ -24,7 +24,3 @@ def load_all(root: str, cluster: str, environment: str, method: str) -> Dict[str
     LOGGER.debug("using config files: %s", configs)
 
     return deep_merge(*[load_yaml(f) for f in configs], method=method)
-
-
-def get_secrets(key: str, default: Any = None) -> Any:
-    return CONFIG.get("secrets", {}).get(key, default)

--- a/k8t/filters.py
+++ b/k8t/filters.py
@@ -83,16 +83,12 @@ def hashf(value, method="sha256"):
 
 def get_secret(key: str, length: int = None) -> str:
     try:
-        default_region = "eu-central-1"
-        provider = getattr(secret_providers, config.CONFIG["secrets"]["provider"].lower())
+        provider_name = config.CONFIG["secrets"]["provider"].lower()
+        provider = getattr(secret_providers, provider_name)
 
-        return provider(
-            "{0}{1}".format(config.CONFIG['secrets']['prefix'], key) if "prefix" in config.CONFIG["secrets"] else key,
-            "{}".format(config.CONFIG['secrets']['region']) if "region" in config.CONFIG["secrets"] else default_region,
-            length
-        )
+        return provider(key, length)
     except AttributeError:
-        raise NotImplementedError("secret provider {} does not exist.".format(config.CONFIG["secrets"]["provider"].lower()))
+        raise NotImplementedError("secret provider {} does not exist.".format(provider_name))
     except KeyError:
         raise RuntimeError("Secrets provider not configured.")
 

--- a/k8t/filters.py
+++ b/k8t/filters.py
@@ -82,7 +82,7 @@ def hashf(value, method="sha256"):
 
 
 def get_secret(key: str, length: int = None) -> str:
-    provider_name = config.get_secrets("provider")
+    provider_name = config.CONFIG.get("secrets", {}).get("provider")
     if not provider_name:
         raise RuntimeError("Secrets provider not configured.")
 

--- a/k8t/filters.py
+++ b/k8t/filters.py
@@ -82,15 +82,17 @@ def hashf(value, method="sha256"):
 
 
 def get_secret(key: str, length: int = None) -> str:
-    try:
-        provider_name = config.CONFIG["secrets"]["provider"].lower()
-        provider = getattr(secret_providers, provider_name)
+    provider_name = config.get_secrets("provider")
+    if not provider_name:
+        raise RuntimeError("Secrets provider not configured.")
 
-        return provider(key, length)
+    provider_name = str(provider_name).lower()
+    try:
+        provider = getattr(secret_providers, provider_name)
     except AttributeError:
         raise NotImplementedError("secret provider {} does not exist.".format(provider_name))
-    except KeyError:
-        raise RuntimeError("Secrets provider not configured.")
+
+    return provider(key, length)
 
 
 def to_bool(value: Any):

--- a/k8t/secret_providers.py
+++ b/k8t/secret_providers.py
@@ -54,8 +54,8 @@ def random(key: str, length: int = None) -> str:
             SystemRandom().choice(string.ascii_lowercase + string.digits) for _ in range(length or SystemRandom().randint(12, 32))
         )
 
-        if length is not None:
-            if len(RANDOM_STORE[key]) != length:
-                raise AssertionError("Secret '{}' did not have expected length of {}".format(key, length))
+    if length is not None:
+        if len(RANDOM_STORE[key]) != length:
+            raise AssertionError("Secret '{}' did not have expected length of {}".format(key, length))
 
     return RANDOM_STORE[key]

--- a/k8t/secret_providers.py
+++ b/k8t/secret_providers.py
@@ -27,10 +27,11 @@ DEFAULT_SSM_REGION = "eu-central-1"
 
 
 def ssm(key: str, length: int = None) -> str:
-    key = str(config.get_secrets("prefix", DEFAULT_SSM_PREFIX)) + key
+    prefix = str(config.CONFIG.get("secrets", {}).get("prefix", DEFAULT_SSM_PREFIX))
+    key = prefix + key
     LOGGER.debug("Requesting secret from %s", key)
 
-    region = str(config.get_secrets("region", DEFAULT_SSM_REGION))
+    region = str(config.CONFIG.get("secrets", {}).get("region", DEFAULT_SSM_REGION))
     client = boto3.client("ssm", region_name=region)
 
     try:

--- a/k8t/secret_providers.py
+++ b/k8t/secret_providers.py
@@ -22,14 +22,15 @@ except ImportError:
 
 LOGGER = logging.getLogger(__name__)
 RANDOM_STORE = {}
+DEFAULT_SSM_PREFIX = ""
+DEFAULT_SSM_REGION = "eu-central-1"
 
 
 def ssm(key: str, length: int = None) -> str:
-    key = "{0}{1}".format(config.CONFIG['secrets']['prefix'], key) if "prefix" in config.CONFIG["secrets"] else key
+    key = str(config.get_secrets("prefix", DEFAULT_SSM_PREFIX)) + key
     LOGGER.debug("Requesting secret from %s", key)
 
-    default_region = "eu-central-1"
-    region = "{}".format(config.CONFIG['secrets']['region']) if "region" in config.CONFIG["secrets"] else default_region
+    region = str(config.get_secrets("region", DEFAULT_SSM_REGION))
     client = boto3.client("ssm", region_name=region)
 
     try:

--- a/k8t/secret_providers.py
+++ b/k8t/secret_providers.py
@@ -12,6 +12,8 @@ import string
 
 import boto3
 
+from k8t import config
+
 try:
     from secrets import SystemRandom
 except ImportError:
@@ -22,9 +24,12 @@ LOGGER = logging.getLogger(__name__)
 RANDOM_STORE = {}
 
 
-def ssm(key: str, region: str, length: int = None) -> str:
+def ssm(key: str, length: int = None) -> str:
+    key = "{0}{1}".format(config.CONFIG['secrets']['prefix'], key) if "prefix" in config.CONFIG["secrets"] else key
     LOGGER.debug("Requesting secret from %s", key)
 
+    default_region = "eu-central-1"
+    region = "{}".format(config.CONFIG['secrets']['region']) if "region" in config.CONFIG["secrets"] else default_region
     client = boto3.client("ssm", region_name=region)
 
     try:

--- a/tests/filters.py
+++ b/tests/filters.py
@@ -12,8 +12,11 @@
 # Author: Aljosha Friemann <aljosha.friemann@clark.de>
 
 import random
+import pytest
+from mock import patch
 
-from k8t.filters import b64decode, b64encode, hashf, random_password, to_bool
+from k8t import config, secret_providers
+from k8t.filters import b64decode, b64encode, hashf, random_password, to_bool, get_secret
 
 
 def test_b64encode():
@@ -38,6 +41,30 @@ def test_hashf():
     assert hashf(string) != string
     assert hashf(string) == hashf(string)
     assert hashf(string) != hashf("foobaz")
+
+
+def test_get_secret():
+    config.CONFIG = {"secrets": {"provider": "random"}}
+    with patch.object(secret_providers, "random") as mock:
+        get_secret("any")
+        mock.assert_called_with("any", None)
+        get_secret("any", 99)
+        mock.assert_called_with("any", 99)
+
+    config.CONFIG = {"secrets": {"provider": "ssm"}}
+    with patch.object(secret_providers, "ssm") as mock:
+        get_secret("any")
+        mock.assert_called_with("any", None)
+        get_secret("any", 99)
+        mock.assert_called_with("any", 99)
+
+    config.CONFIG = {"secrets": {"provider": "nothing"}}
+    with pytest.raises(NotImplementedError, match=r"secret provider nothing does not exist."):
+        get_secret("any")
+
+    config.CONFIG = {}
+    with pytest.raises(RuntimeError, match=r"Secrets provider not configured."):
+        get_secret("any")
 
 
 def test_to_bool():

--- a/tests/secret_providers.py
+++ b/tests/secret_providers.py
@@ -21,9 +21,8 @@ def test_random():
     assert random("/foobar") != random("/foobaz")
 
     assert len(random("/foo", 12)) == 12
-
-    # TODO: Once secret is generated, it ignores length. Have to figure out something with that.
-    # assert len(random("/foo", 10)) == 10
+    with pytest.raises(AssertionError, match=r"Secret '/foo' did not have expected length of 3"):
+        random("/foo", 3)
 
 
 @mock_ssm


### PR DESCRIPTION
Resolves https://github.com/ClarkSource/k8t/issues/54
* Removed region from `ssm` to support same interface for all secret providers
* Refactored `get_secret` filter to avoid using exceptions for flow control (partially)
* Refactored and expanded tests
* Fix random secret length mismatch bug