### PR TITLE
Allow nested values with default filters

### DIFF
--- a/k8t/templates.py
+++ b/k8t/templates.py
@@ -73,7 +73,7 @@ def get_variables(template_path: str, engine) -> Set[str]:
     abstract_syntax_tree = engine.parse(template_source)
 
     defaults = {
-        filter.node.name
+        hasattr(filter.node, "name") and filter.node.name
 
         for filter in abstract_syntax_tree.find_all(nodes.Filter)
 


### PR DESCRIPTION
Error is raised when nested value is used combined with default filter.
### To reproduce:
```
# values.yaml
foo:
  bar: 1
# template.yaml.j2
test: {{foo.bar | default(0) }}
```

### Expected:
```
---
# Source: template.yaml.j2
test: 1
```

### Actual:
```
Traceback (most recent call last):
  File "/usr/local/bin/k8t", line 11, in <module>
    load_entry_point('k8t==0.3.1.dev5+g162fb63', 'console_scripts', 'k8t')()
  File "/usr/local/lib/python3.7/site-packages/k8t-0.3.1.dev5+g162fb63-py3.7.egg/k8t/cli.py", line 293, in main
    root()  # pylint: disable=no-value-for-parameter
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/k8t-0.3.1.dev5+g162fb63-py3.7.egg/k8t/cli.py", line 125, in cli_gen
    if not validate(template_path, vals, eng):
  File "/usr/local/lib/python3.7/site-packages/k8t-0.3.1.dev5+g162fb63-py3.7.egg/k8t/templates.py", line 50, in validate
    undefined, _, invalid, secrets = analyze(template_path, values, engine)
  File "/usr/local/lib/python3.7/site-packages/k8t-0.3.1.dev5+g162fb63-py3.7.egg/k8t/templates.py", line 31, in analyze
    required_variables = get_variables(template_path, engine)
  File "/usr/local/lib/python3.7/site-packages/k8t-0.3.1.dev5+g162fb63-py3.7.egg/k8t/templates.py", line 78, in get_variables
    for filter in abstract_syntax_tree.find_all(nodes.Filter)
  File "/usr/local/lib/python3.7/site-packages/k8t-0.3.1.dev5+g162fb63-py3.7.egg/k8t/templates.py", line 80, in <setcomp>
    if filter.name == "default"
AttributeError: 'Getattr' object has no attribute 'name'
```