### PR TITLE
YAML validation

### DIFF
--- a/k8t/cli.py
+++ b/k8t/cli.py
@@ -18,7 +18,7 @@ from jinja2.exceptions import UndefinedError
 import k8t
 from k8t import cluster, config, environment, project, scaffolding, values
 from k8t.engine import build
-from k8t.templates import analyze, validate
+from k8t.templates import analyze, validate, render, YamlValidationError
 from k8t.util import MERGE_METHODS, deep_merge, envvalues, load_yaml, makedirs
 
 
@@ -134,8 +134,10 @@ def cli_gen(method, value_files, cli_values, cname, ename, directory):  # pylint
         for template_path in templates:
             click.echo("---")
             click.echo("# Source: {}".format(template_path))
-            click.echo(eng.get_template(template_path).render(vals))
-    except UndefinedError as err:
+
+            template_output = render(template_path, vals, eng)
+            click.echo(template_output)
+    except (UndefinedError, YamlValidationError) as err:
         click.secho("✗ -> {}".format(err), fg="red")
         sys.exit(1)
 

--- a/k8t/engine.py
+++ b/k8t/engine.py
@@ -18,7 +18,7 @@ from k8t.project import find_files
 LOGGER = logging.getLogger(__name__)
 
 
-def build(path: str, cluster: str, environment: str):
+def build(path: str, cluster: str, environment: str) -> Environment:
     template_paths = find_template_paths(path, cluster, environment)
 
     LOGGER.debug(

--- a/k8t/templates.py
+++ b/k8t/templates.py
@@ -12,7 +12,7 @@ import os
 from typing import Set, Tuple
 import yaml
 
-from jinja2 import meta, nodes
+from jinja2 import meta, nodes, Environment
 
 from k8t import config
 
@@ -33,7 +33,7 @@ class YamlValidationError(Exception):
     """
 
 
-def analyze(template_path: str, values: dict, engine) -> Tuple[Set[str], Set[str], Set[str], Set[str]]:
+def analyze(template_path: str, values: dict, engine: Environment) -> Tuple[Set[str], Set[str], Set[str], Set[str]]:
     secrets = get_secrets(template_path, engine)
     required_variables = get_variables(template_path, engine)
     defined_variables = set(values.keys())
@@ -52,7 +52,7 @@ def analyze(template_path: str, values: dict, engine) -> Tuple[Set[str], Set[str
     return (undefined_variables - invalid_variables), unused_variables, invalid_variables, secrets
 
 
-def validate(template_path: str, values: dict, engine) -> bool:
+def validate(template_path: str, values: dict, engine: Environment) -> bool:
     config_ok = True
     undefined, _, invalid, secrets = analyze(template_path, values, engine)
 
@@ -73,7 +73,7 @@ def validate(template_path: str, values: dict, engine) -> bool:
     return config_ok and not (invalid or undefined)
 
 
-def get_variables(template_path: str, engine) -> Set[str]:
+def get_variables(template_path: str, engine: Environment) -> Set[str]:
     template_source = engine.loader.get_source(engine, os.path.basename(template_path))[
         0
     ]
@@ -93,7 +93,7 @@ def get_variables(template_path: str, engine) -> Set[str]:
     )
 
 
-def get_secrets(template_path: str, engine) -> Set[str]:
+def get_secrets(template_path: str, engine: Environment) -> Set[str]:
     template_source = engine.loader.get_source(engine, os.path.basename(template_path))[
         0
     ]
@@ -108,7 +108,7 @@ def get_secrets(template_path: str, engine) -> Set[str]:
     }
 
 
-def render(template_path: str, values: dict, engine) -> str:
+def render(template_path: str, values: dict, engine: Environment) -> str:
     output = engine.get_template(template_path).render(values)
 
     try:


### PR DESCRIPTION
It's pretty annoying that if template outputs are not correct yaml files user realises it only when trying to apply configuration to k8s. We should validate templates once they are rendered instead.

Example of failing yaml to test:
```
foo: bar
  buzz:
```