### PR TITLE
Allow subdirectories for templates

### DIFF
--- a/k8t/templates.py
+++ b/k8t/templates.py
@@ -74,7 +74,7 @@ def validate(template_path: str, values: dict, engine: Environment) -> bool:
 
 
 def get_variables(template_path: str, engine: Environment) -> Set[str]:
-    template_source = engine.loader.get_source(engine, os.path.basename(template_path))[
+    template_source = engine.loader.get_source(engine, template_path)[
         0
     ]
     abstract_syntax_tree = engine.parse(template_source)
@@ -94,7 +94,7 @@ def get_variables(template_path: str, engine: Environment) -> Set[str]:
 
 
 def get_secrets(template_path: str, engine: Environment) -> Set[str]:
-    template_source = engine.loader.get_source(engine, os.path.basename(template_path))[
+    template_source = engine.loader.get_source(engine, template_path)[
         0
     ]
     abstract_syntax_tree = engine.parse(template_source)


### PR DESCRIPTION
This PR allows to create nice structured directories for templates. Probably there are some pitfalls that I cannot see, but I've successfully tested it.

Resolves: https://github.com/ClarkSource/k8t/issues/60