### PR TITLE
fix yaml validation for multiple resources in one file

### DIFF
--- a/k8t/templates.py
+++ b/k8t/templates.py
@@ -112,7 +112,7 @@ def render(template_path: str, values: dict, engine: Environment) -> str:
     output = engine.get_template(template_path).render(values)
 
     try:
-        yaml.safe_load(output)
+        yaml.safe_load_all(output)
     except (yaml.scanner.ScannerError, yaml.parser.ParserError) as err:
         raise YamlValidationError(err)
 


### PR DESCRIPTION
fixes issue with multiple resources in one template file

```
09:51:28  Traceback (most recent call last):
09:51:28    File "/usr/local/bin/k8t", line 8, in <module>
09:51:28      sys.exit(main())
09:51:28    File "/usr/local/lib/python3.8/site-packages/k8t/cli.py", line 279, in main
09:51:28      root()  # pylint: disable=no-value-for-parameter
09:51:28    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 829, in __call__
09:51:28      return self.main(*args, **kwargs)
09:51:28    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 782, in main
09:51:28      rv = self.invoke(ctx)
09:51:28    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
09:51:28      return _process_result(sub_ctx.command.invoke(sub_ctx))
09:51:28    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
09:51:28      return ctx.invoke(self.callback, **ctx.params)
09:51:28    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
09:51:28      return callback(*args, **kwargs)
09:51:28    File "/usr/local/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
09:51:28      return f(get_current_context(), *args, **kwargs)
09:51:28    File "/usr/local/lib/python3.8/site-packages/k8t/cli.py", line 32, in new_func
09:51:28      return ctx.invoke(func, *args, **kwargs)
09:51:28    File "/usr/local/lib/python3.8/site-packages/click/core.py", line 610, in invoke
09:51:28      return callback(*args, **kwargs)
09:51:28    File "/usr/local/lib/python3.8/site-packages/k8t/cli.py", line 145, in cli_gen
09:51:28      template_output = render(template_path, vals, eng)
09:51:28    File "/usr/local/lib/python3.8/site-packages/k8t/templates.py", line 115, in render
09:51:28      yaml.safe_load(output)
09:51:28    File "/usr/local/lib/python3.8/site-packages/yaml/__init__.py", line 162, in safe_load
09:51:28      return load(stream, SafeLoader)
09:51:28    File "/usr/local/lib/python3.8/site-packages/yaml/__init__.py", line 114, in load
09:51:28      return loader.get_single_data()
09:51:28    File "/usr/local/lib/python3.8/site-packages/yaml/constructor.py", line 49, in get_single_data
09:51:28      node = self.get_single_node()
09:51:28    File "/usr/local/lib/python3.8/site-packages/yaml/composer.py", line 41, in get_single_node
09:51:28      raise ComposerError("expected a single document in the stream",
09:51:28  yaml.composer.ComposerError: expected a single document in the stream
09:51:28    in "<unicode string>", line 2, column 1:
09:51:28      apiVersion: v1
09:51:28      ^
09:51:28  but found another document
09:51:28    in "<unicode string>", line 15, column 1:
09:51:28      ---
09:51:28      ^
```