### PR TITLE
better error message for ssm client errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ LABEL maintainer="CloudOps <cloudops@clark.de>"
 
 ARG KUBECTL_VERSION="1.18.0"
 
-# Install kubectl
+# Install kubectl & aws-cli
 RUN \
-  apk add --no-cache openssl curl tar gzip bash ca-certificates && \
+  apk add --no-cache openssl curl tar gzip bash ca-certificates aws-cli && \
   curl -L -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
   chmod +x /usr/bin/kubectl && \
   kubectl version --client

--- a/default.nix
+++ b/default.nix
@@ -55,6 +55,6 @@ in
       buildInputs = [
         k8t
         unstable.pre-commit
-        pkgs.python3.pkgs.tox
+        unstable.python3.pkgs.tox
       ];
     }

--- a/k8t/secret_providers.py
+++ b/k8t/secret_providers.py
@@ -46,10 +46,11 @@ def ssm(key: str, length: int = None) -> str:
                 )
 
         return result
-    except botocore.exceptions.ClientError as exc:
+    except (
+        client.exceptions.ParameterNotFound,
+        botocore.exceptions.ClientError,
+    ) as exc:
         raise RuntimeError(f"Failed to retrieve secret {key}: {exc}")
-    except client.exceptions.ParameterNotFound:
-        raise RuntimeError("Could not find secret: {}".format(key))
 
 
 def random(key: str, length: int = None) -> str:

--- a/k8t/util.py
+++ b/k8t/util.py
@@ -8,20 +8,17 @@
 # THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import copy
+import json
 import logging
 import os
 import shutil
-import yaml
-
-from click import secho
 from functools import reduce
-from simple_tools.interaction import confirm
-from typing import Dict, List, Any, Tuple
+from typing import Any, Dict, List, Tuple
 
-try:
-    import ujson as json
-except ImportError:
-    import json
+import yaml
+from click import secho
+
+from simple_tools.interaction import confirm
 
 LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +42,7 @@ def makedirs(path, warn_exists=True):
         if warn_exists:
             if confirm("directory {} already exists, go ahead?".format(path)):
                 secho(f"Directory exists: {path}", fg="yellow")
+
                 return
             raise RuntimeError("aborting")
         secho(f"Directory exists: {path}", fg="yellow")
@@ -74,9 +72,7 @@ def merge(d_1: dict, d_2: dict, path=None, method="ltr"):
     for key in d_2:
         if key in d_1:
             if isinstance(d_1[key], dict) and isinstance(d_2[key], dict):
-                d_1[key] = merge(d_1[key], d_2[key],
-                                 path + [str(key)],
-                                 method=method)
+                d_1[key] = merge(d_1[key], d_2[key], path + [str(key)], method=method)
             elif d_1[key] == d_2[key]:
                 pass  # same leaf value
             else:
@@ -87,8 +83,7 @@ def merge(d_1: dict, d_2: dict, path=None, method="ltr"):
                 elif method == "ask":
                     raise NotImplementedError('Merge method "ask"')
                 elif method == "crash":
-                    raise Exception("Conflict at %s" %
-                                    ".".join(path + [str(key)]))
+                    raise Exception("Conflict at %s" % ".".join(path + [str(key)]))
                 else:
                     raise Exception("Invalid merge method: %s" % method)
         else:
@@ -98,8 +93,7 @@ def merge(d_1: dict, d_2: dict, path=None, method="ltr"):
 
 
 def deep_merge(*dicts, method="ltr"):
-    LOGGER.debug(
-        '"%s" merging %s dicts', method, len(dicts))
+    LOGGER.debug('"%s" merging %s dicts', method, len(dicts))
 
     if not dicts:
         return {}
@@ -126,17 +120,19 @@ def load_cli_value(key: str, value: str) -> Tuple[str, Any]:
 
 
 def envvalues() -> Dict:
-    prefix: str = 'K8T_VALUE_'
+    prefix: str = "K8T_VALUE_"
     values: dict = dict()
 
     for key, value in os.environ.items():
         if key.startswith(prefix):
-            values[key.replace(prefix, '', 1).lower()] = value
+            values[key.replace(prefix, "", 1).lower()] = value
 
     return values
 
 
-def list_files(directory: str, include_files=False, include_directories=False) -> List[str]:
+def list_files(
+    directory: str, include_files=False, include_directories=False
+) -> List[str]:
     result = []
 
     for _, dirs, files in os.walk(directory):

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,6 @@ exclude =
 [isort]
 known_first_party =
   k8t
+
+[flake8]
+max-line-length = 160


### PR DESCRIPTION
some errors with SSM would result in unhelpful error messages, e.g.

```
botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the GetParameter operation: User: arn:aws:sts::123456:assumed-role/myrole is not authorized to perform: ssm:GetParameter on resource: arn:aws:ssm:eu-central-1:12345:*
```

when accessing an invalid parameter path.

this should now return a more helpful error message