### PR TITLE
Fix for `get clusters` command

### DIFF
--- a/k8t/cluster.py
+++ b/k8t/cluster.py
@@ -8,18 +8,17 @@
 # THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 import os
-from typing import List
+from typing import Set
 
-from k8t.project import find_files
+from k8t.util import list_files
 
 
-def list_all(path: str) -> List[str]:
-    result: List[str] = []
+def list_all(path: str) -> Set[str]:
+    cluster_dir = os.path.join(path, 'clusters')
 
-    for directory in find_files(path, None, None, 'environments', file_ok=False, dir_ok=True):
-        for _, dirs, _ in os.walk(directory):
-            result.extend(dirs)
+    result = set()
 
-            break
+    if os.path.isdir(cluster_dir):
+        result.update(list_files(cluster_dir, include_directories=True))
 
     return result

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -139,10 +139,8 @@ def test_get_clusters():
 
     result = runner.invoke(root, ['get', 'clusters', 'tests/dummy/k8t'])
     assert result.exit_code == 0
-    # TODO: Fix that, should return clusters, not environments
-    assert 'some-env' in result.output
-    assert 'common-env' in result.output
-    assert 'cluster-specific-env' not in result.output
+    assert 'cluster-1' in result.output
+    assert 'cluster-2' in result.output
 
 def test_get_environments():
     runner = CliRunner()


### PR DESCRIPTION
Currently `get clusters` return environments, but should return available clusters instead.
Based on https://github.com/ClarkSource/k8t/pull/83