### PR TITLE
YAML validation fix

### DIFF
--- a/k8t/cli.py
+++ b/k8t/cli.py
@@ -85,6 +85,15 @@ def cli_validate(method, value_files, cli_values, cname, ename, suffixes, direct
     for template_path in templates:
         errors = set()
 
+        try:
+            render(template_path, vals, eng)
+        except YamlValidationError as err:
+            click.secho("{}: ✗".format(template_path), fg="red")
+            click.echo("- {}".format(err))
+            continue
+        except: # pylint: disable=bare-except
+            pass
+
         undefined, _, invalid, secrets = analyze(template_path, vals, eng)
 
         if undefined or invalid:

--- a/k8t/templates.py
+++ b/k8t/templates.py
@@ -25,6 +25,7 @@ PROHIBITED_VARIABLE_NAMES = {
     'lipsum',
     'joiner'
 }
+YAML_DELIMETER = '---'
 
 
 class YamlValidationError(Exception):
@@ -110,9 +111,13 @@ def get_variables(ast, engine: Environment) -> Set[str]:
 def render(template_path: str, values: dict, engine: Environment) -> str:
     output = engine.get_template(template_path).render(values)
 
-    try:
-        yaml.safe_load_all(output)
-    except (yaml.scanner.ScannerError, yaml.parser.ParserError) as err:
-        raise YamlValidationError(err)
+    validate_yaml(output)
 
     return output
+
+def validate_yaml(stream: str):
+    try:
+        for document in stream.split(YAML_DELIMETER):
+            yaml.safe_load(document)
+    except (yaml.scanner.ScannerError, yaml.parser.ParserError) as err:
+        raise YamlValidationError(err)

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -314,8 +314,8 @@ def test_validate_failure():
     assert 'several-template.yaml.j2: ✗' in result.output
     assert 'value-template.yaml.j2: ✗' in result.output
     assert 'composite-template.yaml.j2: ✗' in result.output
-    # assert 'invalid-yaml-template.yaml.j2: ✗' in result.output
-    # assert 'composite-invalid-yaml-template.yaml.j2: ✗' in result.output
+    assert 'invalid-yaml-template.yaml.j2: ✗' in result.output
+    assert 'composite-invalid-yaml-template.yaml.j2: ✗' in result.output
 
 @mock_ssm
 def test_gen():

--- a/tests/resources/bad/templates/composite-template.yaml.j2
+++ b/tests/resources/bad/templates/composite-template.yaml.j2
@@ -7,4 +7,5 @@ four: {{ four }}
 one: 1
 two: 2
 three: {{ 2 + 1 }}
-four: {{ four }}
+four: 4
+five: {{ four }}


### PR DESCRIPTION
Previously we changed `yaml.safe_load` to `yaml.safe_load_all` to support multiple document yamls. But `safe_load_all` does not throw any exceptions if yaml format is incorrect. This PR brings back usage of `safe_load`, but takes into account multiple document yamls.
Based on https://github.com/ClarkSource/k8t/pull/83