### PR TITLE
generation would fail on for loops due to missing `name` attribute

### DIFF
--- a/examples/single-cluster/templates/hello-world-deployment.yaml.j2
+++ b/examples/single-cluster/templates/hello-world-deployment.yaml.j2
@@ -31,8 +31,8 @@ spec:
           requests:
             cpu: "{{ request_cpu }}"
             memory: "{{ request_memory }}"
-        {% if env_vars is defined %}
-        {% for key, value in env_vars.items() %}
+        {% if env_vars is defined -%}
+        {% for key, value in env_vars.items() -%}
         env:
         - name: "{{ key }}"
           value: "{{ value }}"

--- a/examples/single-cluster/templates/hello-world-deployment.yaml.j2
+++ b/examples/single-cluster/templates/hello-world-deployment.yaml.j2
@@ -31,3 +31,10 @@ spec:
           requests:
             cpu: "{{ request_cpu }}"
             memory: "{{ request_memory }}"
+        {% if env_vars is defined %}
+        {% for key, value in env_vars.items() %}
+        env:
+        - name: "{{ key }}"
+          value: "{{ value }}"
+        {% endfor %}
+        {%- endif %}

--- a/examples/single-cluster/values.yaml
+++ b/examples/single-cluster/values.yaml
@@ -10,3 +10,6 @@ limit_memory: 256M
 limit_cpu: 200m
 
 traffic_port: 3000
+
+env_vars:
+  FOO: BAR

--- a/k8t/templates.py
+++ b/k8t/templates.py
@@ -10,9 +10,9 @@
 import logging
 import os
 from typing import Set, Tuple
-import yaml
 
-from jinja2 import meta, nodes, Environment
+import yaml
+from jinja2 import Environment, meta, nodes
 
 from k8t import config
 
@@ -37,7 +37,7 @@ def analyze(template_path: str, values: dict, engine: Environment) -> Tuple[Set[
     template_source = engine.loader.get_source(engine, template_path)[0]
     abstract_syntax_tree = engine.parse(template_source)
 
-    has_secrets = any(call.node.name == "get_secret" for call in abstract_syntax_tree.find_all(nodes.Call))
+    has_secrets = any(getattr(call.node, "name", None) == "get_secret" for call in abstract_syntax_tree.find_all(nodes.Call))
     required_variables = get_variables(abstract_syntax_tree, engine)
 
     defined_variables = set(values.keys())


### PR DESCRIPTION
The Getattr node type that is used in e.g. `{% for key, value in cronjob.items() %}{% endfor %}` has no name attribute and would cause an exception:

```
Getattr(node=Name(name='cronjobs', ctx='load'), attr='iteritems', ctx='load')
```

this should fix the issue