### PR TITLE
add `range` example to single-cluster

### DIFF
--- a/examples/single-cluster/templates/hello-world-secret.yaml.j2
+++ b/examples/single-cluster/templates/hello-world-secret.yaml.j2
@@ -8,3 +8,6 @@ metadata:
 type: Opaque
 data:
   PASSWORD: "{{ get_secret('/application', 24) | b64encode }}"
+  {%- for n in range(num_values) %}
+  VALUE{{ n }}: "{{ n }}"
+  {%- endfor %}

--- a/examples/single-cluster/values.yaml
+++ b/examples/single-cluster/values.yaml
@@ -13,3 +13,5 @@ traffic_port: 3000
 
 env_vars:
   FOO: BAR
+
+num_values: 10


### PR DESCRIPTION
to make sure native functions work properly