### PR TITLE
Fix errors in generated templates

### DIFF
--- a/k8t/assets/deployment.yaml.j2
+++ b/k8t/assets/deployment.yaml.j2
@@ -6,8 +6,8 @@ metadata:
   labels:
     app.kubernetes.io/name: "{{ name }}"
 spec:
-  replicas: "{{ replicas }}"
-  revisionHistoryLimit: "{{ revision_history_limit | default(3) }}"
+  replicas: {{ replicas }}
+  revisionHistoryLimit: {{ revision_history_limit | default(3) }}
   selector:
     matchLabels:
       app.kubernetes.io/name: "{{ name }}"
@@ -19,7 +19,7 @@ spec:
     spec:
       restartPolicy: "{{ restart_policy | default('Always') }}"
       securityContext:
-        runAsUser: "{{ user_id | default(1000) }}"
+        runAsUser: {{ user_id | default(1000) }}
       containers:
       - name: "{{ name }}"
         image: "{{ image_repository }}:{{ image_tag }}"

--- a/k8t/assets/service.yaml.j2
+++ b/k8t/assets/service.yaml.j2
@@ -10,5 +10,5 @@ spec:
     app.kubernetes.io/name: "{{ name }}"
   ports:
   - protocol: TCP
-    port: "{{ service_port | default(80) }}"
-    targetPort: "{{ traffic_port }}"
+    port: {{ service_port | default(80) }}
+    targetPort: {{ traffic_port }}


### PR DESCRIPTION
Fixes some values which are expected to be a number by k8s. This happens for all these values, but there can be more as well.

Eg: 
```
error validating "manifest.yaml": error validating data: ValidationError(Deployment.spec.template.spec.securityContext.runAsUser): invalid type for io.k8s.api.core.v1.PodSecurityContext.runAsUser: got "string", expected "integer"; if you choose to ignore these errors, turn validation off with --validate=false
```