### PR TITLE
Allow unconfigured secrets provider if it is passed via cli args

### DIFF
--- a/k8t/cli.py
+++ b/k8t/cli.py
@@ -133,7 +133,10 @@ def cli_gen(method, value_files, cli_values, cname, ename, suffixes, secret_prov
     config.CONFIG = config.load_all(directory, cname, ename, method)
 
     if secret_provider is not None:
-        config.CONFIG['secrets']['provider'] = secret_provider
+        config.CONFIG = deep_merge(
+            config.CONFIG,
+            {'secrets': {'provider': secret_provider}}
+        )
 
     eng = build(directory, cname, ename)
 

--- a/tests/cli.py
+++ b/tests/cli.py
@@ -383,5 +383,11 @@ def test_gen():
         assert result.exit_code == 0
         assert result.output == file.read()
 
+    result = runner.invoke(root, ['gen', 'tests/resources/no_secrets_provider'])
+    assert result.exit_code == 1
+
+    result = runner.invoke(root, ['gen', '--secret-provider', 'random', 'tests/resources/no_secrets_provider'])
+    assert result.exit_code == 0
+
 
 # vim: fenc=utf-8:ts=4:sw=4:expandtab

--- a/tests/resources/no_secrets_provider/templates/template.yaml.j2
+++ b/tests/resources/no_secrets_provider/templates/template.yaml.j2
@@ -1,0 +1,1 @@
+secret: "{{get_secret('/test', 12) | b64encode}}"


### PR DESCRIPTION
If there's `get_secret` in templates and user passes secret provider via cli argument - it shouldn't raise any exceptions. However if k8t cannot find any secret provider - it will raise.

Fixes https://github.com/ClarkSource/k8t/issues/79