### PR TITLE
feat: allow overriding templates in gen and validate

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
 source_up
 
-which use_nix &>/dev/null && use_nix
+which nix-shell &>/dev/null && use_nix
 
 layout python
 

--- a/k8t/util.py
+++ b/k8t/util.py
@@ -145,3 +145,7 @@ def list_files(
         break
 
     return result
+
+def read_file(path: str) -> str:
+    with open(path, 'rb') as stream:
+        return stream.read().decode()


### PR DESCRIPTION
Can now use `-t` or `--template-file` in `gen` and `validate` calls to restrict rendering to certain files. These don't have to be in the usual template folder but could be anywhere.