### PR TITLE
Update docker image to mitigate vulnerabilities

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,6 +10,19 @@ categories:
       - 'fix'
       - 'bugfix'
       - 'bug'
+  - title: 'Other changes'
+    labels:
+      - 'chore'
+      - 'docs'
+      - 'style'
+      - 'perf'
+      - 'test'
+  - title: 'Breaking Changes'
+    labels:
+      - 'chore!'
+      - 'fix!'
+      - 'bugfix!'
+      - 'bug!'
 template: |
   ## Changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,27 +3,20 @@ FROM python:3-alpine
 LABEL maintainer="CloudOps <cloudops@clark.de>"
 
 ARG KUBECTL_VERSION="1.20.5"
-ARG KUBEVAL_VERSION="0.16.1"
 ARG KUBECTL_SHA="7f9dbb80190945a5077dc5f4230202c22f68f9bd7f20c213c3cf5a74abf55e56"
-ARG KUBEVAL_SHA="2d6f9bda1423b93787fa05d9e8dfce2fc1190fefbcd9d0936b9635f3f78ba790"
 
 # Download and install tools
 RUN apk update && apk upgrade && \
     apk add --no-cache openssl curl tar gzip bash ca-certificates py3-wheel
 
 RUN \
-  echo -e "${KUBECTL_SHA}  /tmp/kubectl\n${KUBEVAL_SHA}  /tmp/kubeval.tar.gz" >> /tmp/CHECKSUMS && \
+  echo -e "${KUBECTL_SHA}  /tmp/kubectl" >> /tmp/CHECKSUMS && \
   curl -L -o /tmp/kubectl "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
-  curl -L -o /tmp/kubeval.tar.gz "https://github.com/instrumenta/kubeval/releases/download/v${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz" && \
   sha256sum /tmp/kub* && \
   sha256sum -c /tmp/CHECKSUMS && \
   # install kubectl
   mv /tmp/kubectl /usr/bin/kubectl && \
   chmod +x /usr/bin/kubectl && \
-  # install kubeval
-  mkdir /opt/kubeval && \
-  tar -xzf /tmp/kubeval.tar.gz -C /opt/kubeval && \
-  ln -s /opt/kubeval/kubeval /usr/bin/kubeval && \
   pip install --upgrade awscli
 
 # Install app

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3-alpine
 
 LABEL maintainer="CloudOps <cloudops@clark.de>"
 
-ARG KUBECTL_VERSION="1.20.5"
-ARG KUBECTL_SHA="7f9dbb80190945a5077dc5f4230202c22f68f9bd7f20c213c3cf5a74abf55e56"
+ARG KUBECTL_VERSION="1.22.6"
+ARG KUBECTL_SHA="1ab07643807a45e2917072f7ba5f11140b40f19675981b199b810552d6af5c53"
 
 # Download and install tools
 RUN apk update && apk upgrade && \

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can also run k8t via docker
 $ docker run clarksource/k8t:latest
 ```
 
-**hint**: the docker image comes with [aws-cli](https://aws.amazon.com/cli/), [kubectl](https://github.com/kubernetes/kubectl) and [kubeval](https://github.com/instrumenta/kubeval).
+**hint**: the docker image comes with [aws-cli](https://aws.amazon.com/cli/), and [kubectl](https://github.com/kubernetes/kubectl).
 
 ### Completion
 


### PR DESCRIPTION
- Bump alpine version (during new image build)
- Remove kubeval as it is no longer used
- Update kubectl to 1.22.6

PR adds more commit categories for release drafter