### PR TITLE
feat(ssm): add optional role assumption to ssm client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Simple cluster and environment specific aware templating for kubernetes manifest
   - [Managing secrets](#managing-secrets)
     - [Providers](#providers)
       - [SSM](#ssm)
+        - [role assumption](#role-assumption)
       - [Random](#random)
+      - [Hash](#hash)
 - [TODO](#todo)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -288,6 +290,17 @@ secrets:
 > Keep in mind that SSM parameter names can be formed as a path and  they can only consist of sub-paths divided by slash symbol; each sub-path can be formed as a mix of letters, numbers and the following 3 symbols: `.-_`
 >
 > Be careful to follow this format when setting up the provider `prefix` and `get_secret(key)`.
+
+###### role assumption
+
+You can optionally assume an IAM role to retrieve secrets by specyfing `role_arn` in the config:
+
+```
+secrets:
+  provider: ssm
+  region: "eu-central-1"
+  role_arn: "arn:aws:iam::account:role/role-name-with-path"
+```
 
 ##### Random
 

--- a/k8t/secret_providers.py
+++ b/k8t/secret_providers.py
@@ -33,11 +33,11 @@ def ssm(key: str, length: Optional[int] = None) -> str:
 
     prefix = str(secrets_config.get("prefix", DEFAULT_SSM_PREFIX))
     region = str(secrets_config.get("region", DEFAULT_SSM_REGION))
-    role_arn = str(secrets_config.get("role_arn"))
+    role_arn = str(secrets_config.get("role_arn", ""))
 
     client_config = dict(region_name=region)
 
-    if (role_arn is not None):
+    if role_arn != '':
         sts_client = boto3.client('sts', region_name=region)
 
         LOGGER.debug("assuming role %s", role_arn)
@@ -67,9 +67,7 @@ def ssm(key: str, length: Optional[int] = None) -> str:
 
         if length is not None:
             if len(result) != length:
-                raise AssertionError(
-                    "Secret '{}' did not have expected length of {}".format(key, length)
-                )
+                raise AssertionError(f"Secret '{key}' did not have expected length of {length}")
 
         return result
     except (
@@ -91,9 +89,7 @@ def random(key: str, length: Optional[int] = None) -> str:
 
     if length is not None:
         if len(RANDOM_STORE[key]) != length:
-            raise AssertionError(
-                "Secret '{}' did not have expected length of {}".format(key, length)
-            )
+            raise AssertionError(f"Secret '{key}' did not have expected length of {length}")
 
     return RANDOM_STORE[key]
 


### PR DESCRIPTION
add optional `role_arn` in ssm config to allow role assumption before retrieving SSM parameters