### PR TITLE
Add support for pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+---
+- id: k8t-validate
+  name: k8t validate
+  description: This hook validates k8t manifests
+  entry: k8t
+  args: [ "validate" ]
+  language: python
+  pass_filenames: false
+  always_run: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,3 +7,11 @@
   language: python
   pass_filenames: false
   always_run: true
+- id: k8t-generate
+  name: k8t generate
+  description: This hook generates k8t manifests
+  entry: pre_commit_hooks/k8t-generate
+  language: script
+  pass_filenames: false
+  always_run: true
+  args: [ "-o", "k8t-generated.yaml" ]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Simple cluster and environment specific aware templating for kubernetes manifest
         - [role assumption](#role-assumption)
       - [Random](#random)
       - [Hash](#hash)
+  - [Using as a pre-commit hook](#using-as-a-pre-commit-hook)
 - [TODO](#todo)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -319,6 +320,22 @@ In case consistent (fake) secrets are needed, the `hash` provider can be used th
 ```yaml
 secrets:
   provider: hash
+```
+### Using as a pre-commit hook
+
+You can also use this repo as a https://github.com/pre-commit/pre-commit hook
+
+Add this to your `.pre-commit-config.yaml`:
+
+```yaml
+-   repo: https://github.com/ClarkSource/k8t
+    rev: ''  # Use the sha / tag you want to point at
+    hooks:
+    -   id: k8t-validate
+        # args: [ -e dev -c us-west-2 ]
+    -   id: k8t-generate
+        name: k8t(dev)
+        args: [ -o dev.yaml -e dev ]
 ```
 
 ## TODO

--- a/pre_commit_hooks/k8t-generate
+++ b/pre_commit_hooks/k8t-generate
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+declare -a K8T_ARGS
+OUTPUT=""
+
+usage() {
+  echo "usage: $0 -o <output> [-e env] [-c cluster]" >&2
+  exit 1
+}
+
+while getopts "o:c:e:" options; do
+  
+  case "${options}" in 
+    o)
+      OUTPUT=${OPTARG}
+      ;;
+    c)
+      CLUSTER=${OPTARG}
+      K8T_ARGS+=("-c" "$CLUSTER")
+      ;;
+    e)
+      ENVIRONMENT=${OPTARG}
+      K8T_ARGS+=("-e" "$ENVIRONMENT")
+      ;;
+    *) 
+      usage
+      ;;
+  esac
+  
+done
+
+if [[ -z "$OUTPUT" ]]; then
+  usage
+fi
+
+exec k8t gen "${K8T_ARGS[@]}" > "$OUTPUT"


### PR DESCRIPTION
Add support for 2 [pre-commit](https://pre-commit.com/) hooks:
 - k8t-validate
 - k8t-generate

Would make it easy to both validate k8t files but to also maintain generated files with k8t.